### PR TITLE
feat(ui): 同步窗口最大化状态并订阅主进程变更

### DIFF
--- a/src/main/app/window-manager.ts
+++ b/src/main/app/window-manager.ts
@@ -34,6 +34,18 @@ export class WindowManager {
       }
     })
 
+    // 同步最大化状态变更到渲染进程（包括拖拽导致的还原/最大化）
+    this.mainWindow.on('maximize', () => {
+      try {
+        this.mainWindow?.webContents.send('window-maximize-changed', true)
+      } catch {}
+    })
+    this.mainWindow.on('unmaximize', () => {
+      try {
+        this.mainWindow?.webContents.send('window-maximize-changed', false)
+      } catch {}
+    })
+
     // 添加错误处理
     this.mainWindow.webContents.on('did-fail-load', (event, errorCode, errorDescription) => {
       console.error('页面加载失败:', errorCode, errorDescription)

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -1,8 +1,23 @@
-import { ElectronAPI } from '@electron-toolkit/preload'
+export {}
 
 declare global {
   interface Window {
-    electron: ElectronAPI
-    api: unknown
+    electron: {
+      ipcRenderer: {
+        send: (channel: string, ...args: any[]) => void
+        invoke: (channel: string, ...args: any[]) => Promise<any>
+        on: (channel: string, listener: (...args: any[]) => void) => void
+        removeAllListeners: (channel: string) => void
+      }
+    }
+    api: {
+      window: {
+        minimize: () => Promise<void>
+        maximize: () => Promise<boolean>
+        close: () => Promise<void>
+        isMaximized: () => Promise<boolean>
+        onMaximizeChanged?: (callback: (isMaximized: boolean) => void) => () => void
+      }
+    }
   }
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -8,7 +8,12 @@ const api = {
     minimize: () => ipcRenderer.invoke('window-minimize'),
     maximize: () => ipcRenderer.invoke('window-maximize'),
     close: () => ipcRenderer.invoke('window-close'),
-    isMaximized: () => ipcRenderer.invoke('window-is-maximized')
+    isMaximized: () => ipcRenderer.invoke('window-is-maximized'),
+    onMaximizeChanged: (callback: (isMaximized: boolean) => void) => {
+      const handler = (_: any, state: boolean) => callback(state)
+      ipcRenderer.on('window-maximize-changed', handler)
+      return () => ipcRenderer.removeListener('window-maximize-changed', handler)
+    }
   }
 }
 

--- a/src/renderer/src/components/layout/TitleBar.tsx
+++ b/src/renderer/src/components/layout/TitleBar.tsx
@@ -19,6 +19,18 @@ export default function TitleBar({ title = '现代化桌面应用开发框架' }
     }
     
     checkMaximized()
+
+    // 订阅主进程的最大化状态变更（包括拖拽触发的还原/最大化）
+    let unsubscribe: (() => void) | undefined
+    if (window.api?.window?.onMaximizeChanged) {
+      unsubscribe = window.api.window.onMaximizeChanged((state: boolean) => {
+        setIsMaximized(state)
+      })
+    }
+
+    return () => {
+      if (unsubscribe) unsubscribe()
+    }
   }, [])
 
   const handleMinimize = async () => {
@@ -83,7 +95,8 @@ export default function TitleBar({ title = '现代化桌面应用开发框架' }
           title={isMaximized ? '还原窗口' : '最大化窗口'}
         >
           {isMaximized ? (
-            <Copy className="w-4 h-4" />
+            // 复制图标表示“已最大化”状态，这里做水平翻转以符合视觉期望
+            <Copy className="w-4 h-4" style={{ transform: 'scaleX(-1)' }} />
           ) : (
             <Square className="w-4 h-4" />
           )}

--- a/src/renderer/src/types/global.types.ts
+++ b/src/renderer/src/types/global.types.ts
@@ -14,6 +14,7 @@ declare global {
         maximize: () => Promise<boolean>
         close: () => Promise<void>
         isMaximized: () => Promise<boolean>
+        onMaximizeChanged?: (callback: (isMaximized: boolean) => void) => () => void
       }
     }
   }


### PR DESCRIPTION
新增窗口最大化事件的 IPC 通道并在渲染进程订阅，
以保证拖拽或系统操作触发的还原/最大化能实时更新 TitleBar。
主要改动：
- preload 暴露 onMaximizeChanged 接口，返回取消订阅函数。
- 全局类型声明补充 onMaximizeChanged 定义。
- 主进程在 maximize/unmaximize 时发送 window-maximize-changed 事件。
- TitleBar 组件订阅该事件并更新 isMaximized 状态，卸载时取消订阅。
- 将“已最大化”图标水平翻转以符合视觉预期。

这样用户在任意方式改变窗口状态时标题栏图标与提示保持一致，
体验更丝滑（不是魔法，是事件流）。